### PR TITLE
fix: reqq add_req_queue options type none

### DIFF
--- a/app/manager/reqq.py
+++ b/app/manager/reqq.py
@@ -85,7 +85,7 @@ def add_req_queue(payload, type):
     options = {}
 
     for k, v in payload.items():
-        if (k == "options"):
+        if (k == "options" and v is not None):
             options = v
         if payload[k] != None:
             filter_data[k] = v


### PR DESCRIPTION
In function 'add_req_queue',  'payload.items' loop , 'k' maybe type None, so there will throw error in function 'compare_options' when loop 'options.items'